### PR TITLE
example notebooks function default values changed to not mutable

### DIFF
--- a/notebooks/load gtfs timetable to pandas dataframe.ipynb
+++ b/notebooks/load gtfs timetable to pandas dataframe.ipynb
@@ -251,7 +251,10 @@
    },
    "outputs": [],
    "source": [
-    "def localize_dates(data, dt_columns = []):\n",
+    "def localize_dates(data, dt_columns = None):\n",
+    "    if dt_columns is None:\n",
+    "        dt_columns=[]\n",
+    "    \n",
     "    data = data.copy()\n",
     "    \n",
     "    for c in dt_columns:\n",

--- a/notebooks/load siri vehicle locations to pandas dataframe.ipynb
+++ b/notebooks/load siri vehicle locations to pandas dataframe.ipynb
@@ -400,7 +400,10 @@
    },
    "outputs": [],
    "source": [
-    "def localize_dates(data, dt_columns = []):\n",
+    "def localize_dates(data, dt_columns = None):\n",
+    "    if dt_columns is None:\n",
+    "        dt_columns=[]\n",
+    "    \n",
     "    data = data.copy()\n",
     "    \n",
     "    for c in dt_columns:\n",


### PR DESCRIPTION
changed the default values of the `localize_dates` function in two example notebooks to not be mutable to avoid unwanted behavior. added the necessary condition to get the original default values.